### PR TITLE
Set unicode values for glyphs

### DIFF
--- a/sources/baby-shark.ufo/glyphs/A_.glif
+++ b/sources/baby-shark.ufo/glyphs/A_.glif
@@ -1,15 +1,16 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="A" format="2">
-  <advance width="660"/>
-  <outline>
-    <contour>
-      <point x="10" y="0" type="line"/>
-      <point x="330" y="700" type="line"/>
-      <point x="650" y="0" type="line"/>
-      <point x="345" y="0" type="line"/>
-      <point x="345" y="204" type="line"/>
-      <point x="315" y="204" type="line"/>
-      <point x="315" y="0" type="line"/>
-    </contour>
-  </outline>
+	<unicode hex="0041"/>
+	<advance width="660"/>
+	<outline>
+		<contour>
+			<point x="10" y="0" type="line"/>
+			<point x="330" y="700" type="line"/>
+			<point x="650" y="0" type="line"/>
+			<point x="345" y="0" type="line"/>
+			<point x="345" y="204" type="line"/>
+			<point x="315" y="204" type="line"/>
+			<point x="315" y="0" type="line"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/B_.glif
+++ b/sources/baby-shark.ufo/glyphs/B_.glif
@@ -1,32 +1,33 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="B" format="2">
-  <advance width="610"/>
-  <outline>
-    <contour>
-      <point x="10" y="700" type="line"/>
-      <point x="330" y="700" type="line" smooth="yes"/>
-      <point x="461" y="700"/>
-      <point x="550" y="641"/>
-      <point x="550" y="534" type="curve" smooth="yes"/>
-      <point x="550" y="460"/>
-      <point x="525" y="424"/>
-      <point x="479" y="397" type="curve"/>
-      <point x="479" y="385" type="line"/>
-      <point x="564" y="351"/>
-      <point x="600" y="295"/>
-      <point x="600" y="200" type="curve" smooth="yes"/>
-      <point x="600" y="72"/>
-      <point x="499" y="0"/>
-      <point x="336" y="0" type="curve" smooth="yes"/>
-      <point x="10" y="0" type="line"/>
-      <point x="10" y="180" type="line"/>
-      <point x="251" y="180" type="line"/>
-      <point x="251" y="210" type="line"/>
-      <point x="10" y="210" type="line"/>
-      <point x="10" y="510" type="line"/>
-      <point x="221" y="510" type="line"/>
-      <point x="221" y="540" type="line"/>
-      <point x="11" y="540" type="line"/>
-    </contour>
-  </outline>
+	<unicode hex="0042"/>
+	<advance width="610"/>
+	<outline>
+		<contour>
+			<point x="10" y="700" type="line"/>
+			<point x="330" y="700" type="line" smooth="yes"/>
+			<point x="461" y="700"/>
+			<point x="550" y="641"/>
+			<point x="550" y="534" type="curve" smooth="yes"/>
+			<point x="550" y="460"/>
+			<point x="525" y="424"/>
+			<point x="479" y="397" type="curve"/>
+			<point x="479" y="385" type="line"/>
+			<point x="564" y="351"/>
+			<point x="600" y="295"/>
+			<point x="600" y="200" type="curve" smooth="yes"/>
+			<point x="600" y="72"/>
+			<point x="499" y="0"/>
+			<point x="336" y="0" type="curve" smooth="yes"/>
+			<point x="10" y="0" type="line"/>
+			<point x="10" y="180" type="line"/>
+			<point x="251" y="180" type="line"/>
+			<point x="251" y="210" type="line"/>
+			<point x="10" y="210" type="line"/>
+			<point x="10" y="510" type="line"/>
+			<point x="221" y="510" type="line"/>
+			<point x="221" y="540" type="line"/>
+			<point x="11" y="540" type="line"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/C_.glif
+++ b/sources/baby-shark.ufo/glyphs/C_.glif
@@ -1,22 +1,23 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="C" format="2">
-  <advance width="680"/>
-  <outline>
-    <contour>
-      <point x="377" y="348" type="line"/>
-      <point x="670" y="472" type="line" smooth="yes"/>
-      <point x="642" y="598"/>
-      <point x="505" y="699"/>
-      <point x="360" y="700" type="curve" smooth="yes"/>
-      <point x="168" y="701"/>
-      <point x="10" y="540"/>
-      <point x="10" y="349" type="curve" smooth="yes"/>
-      <point x="10" y="157"/>
-      <point x="168" y="-2"/>
-      <point x="359" y="1" type="curve" smooth="yes"/>
-      <point x="510" y="3"/>
-      <point x="652" y="114"/>
-      <point x="670" y="231" type="curve" smooth="yes"/>
-    </contour>
-  </outline>
+	<unicode hex="0043"/>
+	<advance width="680"/>
+	<outline>
+		<contour>
+			<point x="377" y="348" type="line"/>
+			<point x="670" y="472" type="line" smooth="yes"/>
+			<point x="642" y="598"/>
+			<point x="505" y="699"/>
+			<point x="360" y="700" type="curve" smooth="yes"/>
+			<point x="168" y="701"/>
+			<point x="10" y="540"/>
+			<point x="10" y="349" type="curve" smooth="yes"/>
+			<point x="10" y="157"/>
+			<point x="168" y="-2"/>
+			<point x="359" y="1" type="curve" smooth="yes"/>
+			<point x="510" y="3"/>
+			<point x="652" y="114"/>
+			<point x="670" y="231" type="curve" smooth="yes"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/D_.glif
+++ b/sources/baby-shark.ufo/glyphs/D_.glif
@@ -1,21 +1,22 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="D" format="2">
-  <advance width="670"/>
-  <outline>
-    <contour>
-      <point x="14" y="700" type="line"/>
-      <point x="302" y="700" type="line" smooth="yes"/>
-      <point x="499" y="700"/>
-      <point x="660" y="584"/>
-      <point x="660" y="345" type="curve" smooth="yes"/>
-      <point x="660" y="122"/>
-      <point x="549" y="0"/>
-      <point x="349" y="0" type="curve" smooth="yes"/>
-      <point x="10" y="0" type="line"/>
-      <point x="10" y="340" type="line"/>
-      <point x="241" y="340" type="line"/>
-      <point x="241" y="370" type="line"/>
-      <point x="10" y="370" type="line"/>
-    </contour>
-  </outline>
+	<unicode hex="0044"/>
+	<advance width="670"/>
+	<outline>
+		<contour>
+			<point x="14" y="700" type="line"/>
+			<point x="302" y="700" type="line" smooth="yes"/>
+			<point x="499" y="700"/>
+			<point x="660" y="584"/>
+			<point x="660" y="345" type="curve" smooth="yes"/>
+			<point x="660" y="122"/>
+			<point x="549" y="0"/>
+			<point x="349" y="0" type="curve" smooth="yes"/>
+			<point x="10" y="0" type="line"/>
+			<point x="10" y="340" type="line"/>
+			<point x="241" y="340" type="line"/>
+			<point x="241" y="370" type="line"/>
+			<point x="10" y="370" type="line"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/E_.glif
+++ b/sources/baby-shark.ufo/glyphs/E_.glif
@@ -1,20 +1,21 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="E" format="2">
-  <advance width="600"/>
-  <outline>
-    <contour>
-      <point x="10" y="700" type="line"/>
-      <point x="390" y="700" type="line"/>
-      <point x="390" y="530" type="line"/>
-      <point x="220" y="530" type="line"/>
-      <point x="220" y="500" type="line"/>
-      <point x="500" y="500" type="line"/>
-      <point x="500" y="310" type="line"/>
-      <point x="220" y="310" type="line"/>
-      <point x="220" y="280" type="line"/>
-      <point x="590" y="280" type="line"/>
-      <point x="590" y="0" type="line"/>
-      <point x="10" y="0" type="line"/>
-    </contour>
-  </outline>
+	<unicode hex="0045"/>
+	<advance width="600"/>
+	<outline>
+		<contour>
+			<point x="10" y="700" type="line"/>
+			<point x="390" y="700" type="line"/>
+			<point x="390" y="530" type="line"/>
+			<point x="220" y="530" type="line"/>
+			<point x="220" y="500" type="line"/>
+			<point x="500" y="500" type="line"/>
+			<point x="500" y="310" type="line"/>
+			<point x="220" y="310" type="line"/>
+			<point x="220" y="280" type="line"/>
+			<point x="590" y="280" type="line"/>
+			<point x="590" y="0" type="line"/>
+			<point x="10" y="0" type="line"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/F_.glif
+++ b/sources/baby-shark.ufo/glyphs/F_.glif
@@ -1,18 +1,19 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="F" format="2">
-  <advance width="500"/>
-  <outline>
-    <contour>
-      <point x="9" y="0" type="line"/>
-      <point x="12" y="700" type="line"/>
-      <point x="490" y="700" type="line"/>
-      <point x="490" y="490" type="line"/>
-      <point x="253" y="490" type="line"/>
-      <point x="253" y="460" type="line"/>
-      <point x="370" y="460" type="line"/>
-      <point x="370" y="300" type="line"/>
-      <point x="270" y="300" type="line"/>
-      <point x="270" y="0" type="line"/>
-    </contour>
-  </outline>
+	<unicode hex="0046"/>
+	<advance width="500"/>
+	<outline>
+		<contour>
+			<point x="9" y="0" type="line"/>
+			<point x="12" y="700" type="line"/>
+			<point x="490" y="700" type="line"/>
+			<point x="490" y="490" type="line"/>
+			<point x="253" y="490" type="line"/>
+			<point x="253" y="460" type="line"/>
+			<point x="370" y="460" type="line"/>
+			<point x="370" y="300" type="line"/>
+			<point x="270" y="300" type="line"/>
+			<point x="270" y="0" type="line"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/G_.glif
+++ b/sources/baby-shark.ufo/glyphs/G_.glif
@@ -1,24 +1,25 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="G" format="2">
-  <advance width="710"/>
-  <outline>
-    <contour>
-      <point x="383" y="348" type="line"/>
-      <point x="674" y="473" type="line"/>
-      <point x="646" y="605"/>
-      <point x="510" y="710"/>
-      <point x="360" y="711" type="curve" smooth="yes"/>
-      <point x="163" y="712"/>
-      <point x="20" y="540"/>
-      <point x="20" y="349" type="curve" smooth="yes"/>
-      <point x="20" y="157"/>
-      <point x="168" y="-15"/>
-      <point x="359" y="-15" type="curve" smooth="yes"/>
-      <point x="475" y="-15"/>
-      <point x="529" y="29"/>
-      <point x="578" y="88" type="curve"/>
-      <point x="690" y="18" type="line"/>
-      <point x="687" y="348" type="line"/>
-    </contour>
-  </outline>
+	<unicode hex="0047"/>
+	<advance width="710"/>
+	<outline>
+		<contour>
+			<point x="383" y="348" type="line"/>
+			<point x="674" y="473" type="line"/>
+			<point x="646" y="605"/>
+			<point x="510" y="710"/>
+			<point x="360" y="711" type="curve" smooth="yes"/>
+			<point x="163" y="712"/>
+			<point x="20" y="540"/>
+			<point x="20" y="349" type="curve" smooth="yes"/>
+			<point x="20" y="157"/>
+			<point x="168" y="-15"/>
+			<point x="359" y="-15" type="curve" smooth="yes"/>
+			<point x="475" y="-15"/>
+			<point x="529" y="29"/>
+			<point x="578" y="88" type="curve"/>
+			<point x="690" y="18" type="line"/>
+			<point x="687" y="348" type="line"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/H_.glif
+++ b/sources/baby-shark.ufo/glyphs/H_.glif
@@ -1,20 +1,21 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="H" format="2">
-  <advance width="500"/>
-  <outline>
-    <contour>
-      <point x="10" y="700" type="line"/>
-      <point x="235" y="700" type="line"/>
-      <point x="235" y="554" type="line"/>
-      <point x="265" y="554" type="line"/>
-      <point x="265" y="700" type="line"/>
-      <point x="490" y="700" type="line"/>
-      <point x="490" y="0" type="line"/>
-      <point x="265" y="0" type="line"/>
-      <point x="265" y="178" type="line"/>
-      <point x="235" y="178" type="line"/>
-      <point x="235" y="0" type="line"/>
-      <point x="10" y="0" type="line"/>
-    </contour>
-  </outline>
+	<unicode hex="0048"/>
+	<advance width="500"/>
+	<outline>
+		<contour>
+			<point x="10" y="700" type="line"/>
+			<point x="235" y="700" type="line"/>
+			<point x="235" y="554" type="line"/>
+			<point x="265" y="554" type="line"/>
+			<point x="265" y="700" type="line"/>
+			<point x="490" y="700" type="line"/>
+			<point x="490" y="0" type="line"/>
+			<point x="265" y="0" type="line"/>
+			<point x="265" y="178" type="line"/>
+			<point x="235" y="178" type="line"/>
+			<point x="235" y="0" type="line"/>
+			<point x="10" y="0" type="line"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/I_.glif
+++ b/sources/baby-shark.ufo/glyphs/I_.glif
@@ -1,12 +1,13 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="I" format="2">
-  <advance width="300"/>
-  <outline>
-    <contour>
-      <point x="290" y="700" type="line"/>
-      <point x="290" y="0" type="line"/>
-      <point x="10" y="0" type="line"/>
-      <point x="10" y="700" type="line"/>
-    </contour>
-  </outline>
+	<unicode hex="0049"/>
+	<advance width="300"/>
+	<outline>
+		<contour>
+			<point x="290" y="700" type="line"/>
+			<point x="290" y="0" type="line"/>
+			<point x="10" y="0" type="line"/>
+			<point x="10" y="700" type="line"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/J_.glif
+++ b/sources/baby-shark.ufo/glyphs/J_.glif
@@ -1,21 +1,22 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="J" format="2">
-  <advance width="500"/>
-  <outline>
-    <contour>
-      <point x="260" y="700" type="line"/>
-      <point x="490" y="700" type="line"/>
-      <point x="490" y="190" type="line" smooth="yes"/>
-      <point x="490" y="51"/>
-      <point x="416" y="-9"/>
-      <point x="250" y="-10" type="curve" smooth="yes"/>
-      <point x="111" y="-11"/>
-      <point x="12" y="51"/>
-      <point x="10" y="180" type="curve" smooth="yes"/>
-      <point x="10" y="330" type="line"/>
-      <point x="230" y="332" type="line"/>
-      <point x="230" y="180" type="line"/>
-      <point x="260" y="180" type="line"/>
-    </contour>
-  </outline>
+	<unicode hex="004A"/>
+	<advance width="500"/>
+	<outline>
+		<contour>
+			<point x="260" y="700" type="line"/>
+			<point x="490" y="700" type="line"/>
+			<point x="490" y="190" type="line" smooth="yes"/>
+			<point x="490" y="51"/>
+			<point x="416" y="-9"/>
+			<point x="250" y="-10" type="curve" smooth="yes"/>
+			<point x="111" y="-11"/>
+			<point x="12" y="51"/>
+			<point x="10" y="180" type="curve" smooth="yes"/>
+			<point x="10" y="330" type="line"/>
+			<point x="230" y="332" type="line"/>
+			<point x="230" y="180" type="line"/>
+			<point x="260" y="180" type="line"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/K_.glif
+++ b/sources/baby-shark.ufo/glyphs/K_.glif
@@ -1,21 +1,22 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="K" format="2">
-  <advance width="600"/>
-  <outline>
-    <contour>
-      <point x="12" y="700" type="line"/>
-      <point x="230" y="700" type="line"/>
-      <point x="230" y="564" type="line"/>
-      <point x="260" y="564" type="line"/>
-      <point x="260" y="700" type="line"/>
-      <point x="580" y="700" type="line"/>
-      <point x="397" y="387" type="line"/>
-      <point x="590" y="0" type="line"/>
-      <point x="260" y="0" type="line"/>
-      <point x="260" y="160" type="line"/>
-      <point x="230" y="160" type="line"/>
-      <point x="230" y="0" type="line"/>
-      <point x="10" y="0" type="line"/>
-    </contour>
-  </outline>
+	<unicode hex="004B"/>
+	<advance width="600"/>
+	<outline>
+		<contour>
+			<point x="12" y="700" type="line"/>
+			<point x="230" y="700" type="line"/>
+			<point x="230" y="564" type="line"/>
+			<point x="260" y="564" type="line"/>
+			<point x="260" y="700" type="line"/>
+			<point x="580" y="700" type="line"/>
+			<point x="397" y="387" type="line"/>
+			<point x="590" y="0" type="line"/>
+			<point x="260" y="0" type="line"/>
+			<point x="260" y="160" type="line"/>
+			<point x="230" y="160" type="line"/>
+			<point x="230" y="0" type="line"/>
+			<point x="10" y="0" type="line"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/L_.glif
+++ b/sources/baby-shark.ufo/glyphs/L_.glif
@@ -1,14 +1,15 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="L" format="2">
-  <advance width="490"/>
-  <outline>
-    <contour>
-      <point x="10" y="700" type="line"/>
-      <point x="10" y="0" type="line"/>
-      <point x="480" y="0" type="line"/>
-      <point x="480" y="300" type="line"/>
-      <point x="230" y="300" type="line"/>
-      <point x="230" y="700" type="line"/>
-    </contour>
-  </outline>
+	<unicode hex="004C"/>
+	<advance width="490"/>
+	<outline>
+		<contour>
+			<point x="10" y="700" type="line"/>
+			<point x="10" y="0" type="line"/>
+			<point x="480" y="0" type="line"/>
+			<point x="480" y="300" type="line"/>
+			<point x="230" y="300" type="line"/>
+			<point x="230" y="700" type="line"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/M_.glif
+++ b/sources/baby-shark.ufo/glyphs/M_.glif
@@ -1,21 +1,22 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="M" format="2">
-  <advance width="800"/>
-  <outline>
-    <contour>
-      <point x="10" y="720" type="line"/>
-      <point x="400" y="550" type="line"/>
-      <point x="790" y="720" type="line"/>
-      <point x="790" y="0" type="line"/>
-      <point x="535" y="1" type="line"/>
-      <point x="535" y="220" type="line"/>
-      <point x="505" y="220" type="line"/>
-      <point x="505" y="0" type="line"/>
-      <point x="295" y="0" type="line"/>
-      <point x="295" y="220" type="line"/>
-      <point x="265" y="220" type="line"/>
-      <point x="265" y="0" type="line"/>
-      <point x="10" y="0" type="line"/>
-    </contour>
-  </outline>
+	<unicode hex="004D"/>
+	<advance width="800"/>
+	<outline>
+		<contour>
+			<point x="10" y="720" type="line"/>
+			<point x="400" y="550" type="line"/>
+			<point x="790" y="720" type="line"/>
+			<point x="790" y="0" type="line"/>
+			<point x="535" y="1" type="line"/>
+			<point x="535" y="220" type="line"/>
+			<point x="505" y="220" type="line"/>
+			<point x="505" y="0" type="line"/>
+			<point x="295" y="0" type="line"/>
+			<point x="295" y="220" type="line"/>
+			<point x="265" y="220" type="line"/>
+			<point x="265" y="0" type="line"/>
+			<point x="10" y="0" type="line"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/N_.glif
+++ b/sources/baby-shark.ufo/glyphs/N_.glif
@@ -1,18 +1,19 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="N" format="2">
-  <advance width="600"/>
-  <outline>
-    <contour>
-      <point x="10" y="710" type="line"/>
-      <point x="410" y="550" type="line"/>
-      <point x="410" y="700" type="line"/>
-      <point x="590" y="700" type="line"/>
-      <point x="590" y="0" type="line"/>
-      <point x="220" y="0" type="line"/>
-      <point x="220" y="220" type="line"/>
-      <point x="190" y="220" type="line"/>
-      <point x="190" y="0" type="line"/>
-      <point x="10" y="0" type="line"/>
-    </contour>
-  </outline>
+	<unicode hex="004E"/>
+	<advance width="600"/>
+	<outline>
+		<contour>
+			<point x="10" y="710" type="line"/>
+			<point x="410" y="550" type="line"/>
+			<point x="410" y="700" type="line"/>
+			<point x="590" y="700" type="line"/>
+			<point x="590" y="0" type="line"/>
+			<point x="220" y="0" type="line"/>
+			<point x="220" y="220" type="line"/>
+			<point x="190" y="220" type="line"/>
+			<point x="190" y="0" type="line"/>
+			<point x="10" y="0" type="line"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/O_.glif
+++ b/sources/baby-shark.ufo/glyphs/O_.glif
@@ -1,20 +1,21 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="O" format="2">
-  <advance width="800"/>
-  <outline>
-    <contour>
-      <point x="790" y="350" type="curve" smooth="yes"/>
-      <point x="790" y="560"/>
-      <point x="590" y="710"/>
-      <point x="400" y="710" type="curve" smooth="yes"/>
-      <point x="190" y="710"/>
-      <point x="10" y="560"/>
-      <point x="10" y="350" type="curve" smooth="yes"/>
-      <point x="10" y="140"/>
-      <point x="190" y="-7"/>
-      <point x="400" y="-10" type="curve" smooth="yes"/>
-      <point x="590" y="-13"/>
-      <point x="790" y="140"/>
-    </contour>
-  </outline>
+	<unicode hex="004F"/>
+	<advance width="800"/>
+	<outline>
+		<contour>
+			<point x="790" y="350" type="curve" smooth="yes"/>
+			<point x="790" y="560"/>
+			<point x="590" y="710"/>
+			<point x="400" y="710" type="curve" smooth="yes"/>
+			<point x="190" y="710"/>
+			<point x="10" y="560"/>
+			<point x="10" y="350" type="curve" smooth="yes"/>
+			<point x="10" y="140"/>
+			<point x="190" y="-7"/>
+			<point x="400" y="-10" type="curve" smooth="yes"/>
+			<point x="590" y="-13"/>
+			<point x="790" y="140"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/P_.glif
+++ b/sources/baby-shark.ufo/glyphs/P_.glif
@@ -1,23 +1,24 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="P" format="2">
-  <advance width="500"/>
-  <outline>
-    <contour>
-      <point x="10" y="0" type="line"/>
-      <point x="10" y="490" type="line"/>
-      <point x="170" y="490" type="line"/>
-      <point x="170" y="520" type="line"/>
-      <point x="10" y="520" type="line"/>
-      <point x="10" y="700" type="line"/>
-      <point x="300" y="700" type="line" smooth="yes"/>
-      <point x="430" y="700"/>
-      <point x="490" y="635"/>
-      <point x="490" y="500" type="curve" smooth="yes"/>
-      <point x="490" y="380"/>
-      <point x="410" y="330"/>
-      <point x="303" y="330" type="curve" smooth="yes"/>
-      <point x="210" y="330" type="line"/>
-      <point x="210" y="0" type="line"/>
-    </contour>
-  </outline>
+	<unicode hex="0050"/>
+	<advance width="500"/>
+	<outline>
+		<contour>
+			<point x="10" y="0" type="line"/>
+			<point x="10" y="490" type="line"/>
+			<point x="170" y="490" type="line"/>
+			<point x="170" y="520" type="line"/>
+			<point x="10" y="520" type="line"/>
+			<point x="10" y="700" type="line"/>
+			<point x="300" y="700" type="line" smooth="yes"/>
+			<point x="430" y="700"/>
+			<point x="490" y="635"/>
+			<point x="490" y="500" type="curve" smooth="yes"/>
+			<point x="490" y="380"/>
+			<point x="410" y="330"/>
+			<point x="303" y="330" type="curve" smooth="yes"/>
+			<point x="210" y="330" type="line"/>
+			<point x="210" y="0" type="line"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/Q_.glif
+++ b/sources/baby-shark.ufo/glyphs/Q_.glif
@@ -1,22 +1,23 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="Q" format="2">
-  <advance width="800"/>
-  <outline>
-    <contour>
-      <point x="780" y="339" type="curve" smooth="yes"/>
-      <point x="780" y="567"/>
-      <point x="617" y="710"/>
-      <point x="400" y="710" type="curve" smooth="yes"/>
-      <point x="194" y="710"/>
-      <point x="17" y="554"/>
-      <point x="17" y="353" type="curve" smooth="yes"/>
-      <point x="17" y="151"/>
-      <point x="134" y="3"/>
-      <point x="342" y="0" type="curve" smooth="yes"/>
-      <point x="790" y="0" type="line"/>
-      <point x="707" y="131" type="line" smooth="yes"/>
-      <point x="751" y="183"/>
-      <point x="780" y="253"/>
-    </contour>
-  </outline>
+	<unicode hex="0051"/>
+	<advance width="800"/>
+	<outline>
+		<contour>
+			<point x="780" y="339" type="curve" smooth="yes"/>
+			<point x="780" y="567"/>
+			<point x="617" y="710"/>
+			<point x="400" y="710" type="curve" smooth="yes"/>
+			<point x="194" y="710"/>
+			<point x="17" y="554"/>
+			<point x="17" y="353" type="curve" smooth="yes"/>
+			<point x="17" y="151"/>
+			<point x="134" y="3"/>
+			<point x="342" y="0" type="curve" smooth="yes"/>
+			<point x="790" y="0" type="line"/>
+			<point x="707" y="131" type="line" smooth="yes"/>
+			<point x="751" y="183"/>
+			<point x="780" y="253"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/R_.glif
+++ b/sources/baby-shark.ufo/glyphs/R_.glif
@@ -1,26 +1,27 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="R" format="2">
-  <advance width="600"/>
-  <outline>
-    <contour>
-      <point x="10" y="0" type="line"/>
-      <point x="10" y="460" type="line"/>
-      <point x="165" y="460" type="line"/>
-      <point x="165" y="490" type="line"/>
-      <point x="10" y="490" type="line"/>
-      <point x="10" y="700" type="line"/>
-      <point x="359" y="700" type="line" smooth="yes"/>
-      <point x="493" y="699"/>
-      <point x="580" y="609"/>
-      <point x="580" y="480" type="curve" smooth="yes"/>
-      <point x="580" y="381"/>
-      <point x="539" y="320"/>
-      <point x="463" y="293" type="curve" smooth="yes"/>
-      <point x="590" y="0" type="line"/>
-      <point x="266" y="0" type="line"/>
-      <point x="266" y="260" type="line"/>
-      <point x="236" y="260" type="line"/>
-      <point x="236" y="0" type="line"/>
-    </contour>
-  </outline>
+	<unicode hex="0052"/>
+	<advance width="600"/>
+	<outline>
+		<contour>
+			<point x="10" y="0" type="line"/>
+			<point x="10" y="460" type="line"/>
+			<point x="165" y="460" type="line"/>
+			<point x="165" y="490" type="line"/>
+			<point x="10" y="490" type="line"/>
+			<point x="10" y="700" type="line"/>
+			<point x="359" y="700" type="line" smooth="yes"/>
+			<point x="493" y="699"/>
+			<point x="580" y="609"/>
+			<point x="580" y="480" type="curve" smooth="yes"/>
+			<point x="580" y="381"/>
+			<point x="539" y="320"/>
+			<point x="463" y="293" type="curve" smooth="yes"/>
+			<point x="590" y="0" type="line"/>
+			<point x="266" y="0" type="line"/>
+			<point x="266" y="260" type="line"/>
+			<point x="236" y="260" type="line"/>
+			<point x="236" y="0" type="line"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/S_.glif
+++ b/sources/baby-shark.ufo/glyphs/S_.glif
@@ -1,28 +1,29 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="S" format="2">
-  <advance width="500"/>
-  <outline>
-    <contour>
-      <point x="446" y="567" type="line" smooth="yes"/>
-      <point x="420" y="654"/>
-      <point x="349" y="710"/>
-      <point x="234" y="710" type="curve" smooth="yes"/>
-      <point x="117" y="710"/>
-      <point x="20" y="607"/>
-      <point x="20" y="506" type="curve" smooth="yes"/>
-      <point x="20" y="420"/>
-      <point x="53" y="356"/>
-      <point x="103" y="313" type="curve" smooth="yes"/>
-      <point x="10" y="232" type="line" smooth="yes"/>
-      <point x="10" y="115"/>
-      <point x="112" y="-10"/>
-      <point x="248" y="-10" type="curve" smooth="yes"/>
-      <point x="398" y="-10"/>
-      <point x="490" y="116"/>
-      <point x="490" y="226" type="curve" smooth="yes"/>
-      <point x="490" y="352"/>
-      <point x="443" y="420"/>
-      <point x="351" y="487" type="curve" smooth="yes"/>
-    </contour>
-  </outline>
+	<unicode hex="0053"/>
+	<advance width="500"/>
+	<outline>
+		<contour>
+			<point x="446" y="567" type="line" smooth="yes"/>
+			<point x="420" y="654"/>
+			<point x="349" y="710"/>
+			<point x="234" y="710" type="curve" smooth="yes"/>
+			<point x="117" y="710"/>
+			<point x="20" y="607"/>
+			<point x="20" y="506" type="curve" smooth="yes"/>
+			<point x="20" y="420"/>
+			<point x="53" y="356"/>
+			<point x="103" y="313" type="curve" smooth="yes"/>
+			<point x="10" y="232" type="line" smooth="yes"/>
+			<point x="10" y="115"/>
+			<point x="112" y="-10"/>
+			<point x="248" y="-10" type="curve" smooth="yes"/>
+			<point x="398" y="-10"/>
+			<point x="490" y="116"/>
+			<point x="490" y="226" type="curve" smooth="yes"/>
+			<point x="490" y="352"/>
+			<point x="443" y="420"/>
+			<point x="351" y="487" type="curve" smooth="yes"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/T_.glif
+++ b/sources/baby-shark.ufo/glyphs/T_.glif
@@ -1,16 +1,17 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="T" format="2">
-  <advance width="500"/>
-  <outline>
-    <contour>
-      <point x="10" y="700" type="line"/>
-      <point x="490" y="699" type="line"/>
-      <point x="490" y="520" type="line"/>
-      <point x="350" y="520" type="line"/>
-      <point x="350" y="0" type="line"/>
-      <point x="150" y="0" type="line"/>
-      <point x="150" y="520" type="line"/>
-      <point x="10" y="520" type="line"/>
-    </contour>
-  </outline>
+	<unicode hex="0054"/>
+	<advance width="500"/>
+	<outline>
+		<contour>
+			<point x="10" y="700" type="line"/>
+			<point x="490" y="699" type="line"/>
+			<point x="490" y="520" type="line"/>
+			<point x="350" y="520" type="line"/>
+			<point x="350" y="0" type="line"/>
+			<point x="150" y="0" type="line"/>
+			<point x="150" y="520" type="line"/>
+			<point x="10" y="520" type="line"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/U_.glif
+++ b/sources/baby-shark.ufo/glyphs/U_.glif
@@ -1,21 +1,22 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="U" format="2">
-  <advance width="500"/>
-  <outline>
-    <contour>
-      <point x="10" y="700" type="line"/>
-      <point x="235" y="700" type="line"/>
-      <point x="235" y="437" type="line"/>
-      <point x="265" y="437" type="line"/>
-      <point x="265" y="700" type="line"/>
-      <point x="490" y="700" type="line"/>
-      <point x="490" y="250" type="line" smooth="yes"/>
-      <point x="490" y="80"/>
-      <point x="400" y="-11"/>
-      <point x="250" y="-10" type="curve" smooth="yes"/>
-      <point x="100" y="-9"/>
-      <point x="10" y="80"/>
-      <point x="10" y="250" type="curve" smooth="yes"/>
-    </contour>
-  </outline>
+	<unicode hex="0055"/>
+	<advance width="500"/>
+	<outline>
+		<contour>
+			<point x="10" y="700" type="line"/>
+			<point x="235" y="700" type="line"/>
+			<point x="235" y="437" type="line"/>
+			<point x="265" y="437" type="line"/>
+			<point x="265" y="700" type="line"/>
+			<point x="490" y="700" type="line"/>
+			<point x="490" y="250" type="line" smooth="yes"/>
+			<point x="490" y="80"/>
+			<point x="400" y="-11"/>
+			<point x="250" y="-10" type="curve" smooth="yes"/>
+			<point x="100" y="-9"/>
+			<point x="10" y="80"/>
+			<point x="10" y="250" type="curve" smooth="yes"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/V_.glif
+++ b/sources/baby-shark.ufo/glyphs/V_.glif
@@ -1,15 +1,16 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="V" format="2">
-  <advance width="600"/>
-  <outline>
-    <contour>
-      <point x="10" y="700" type="line"/>
-      <point x="290" y="700" type="line"/>
-      <point x="290" y="480" type="line"/>
-      <point x="320" y="480" type="line"/>
-      <point x="320" y="700" type="line"/>
-      <point x="590" y="700" type="line"/>
-      <point x="300" y="-20" type="line"/>
-    </contour>
-  </outline>
+	<unicode hex="0056"/>
+	<advance width="600"/>
+	<outline>
+		<contour>
+			<point x="10" y="700" type="line"/>
+			<point x="290" y="700" type="line"/>
+			<point x="290" y="480" type="line"/>
+			<point x="320" y="480" type="line"/>
+			<point x="320" y="700" type="line"/>
+			<point x="590" y="700" type="line"/>
+			<point x="300" y="-20" type="line"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/W_.glif
+++ b/sources/baby-shark.ufo/glyphs/W_.glif
@@ -1,21 +1,22 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="W" format="2">
-  <advance width="900"/>
-  <outline>
-    <contour>
-      <point x="10" y="700" type="line"/>
-      <point x="300" y="-20" type="line"/>
-      <point x="450" y="220" type="line"/>
-      <point x="600" y="-20" type="line"/>
-      <point x="890" y="700" type="line"/>
-      <point x="595" y="700" type="line"/>
-      <point x="595" y="480" type="line"/>
-      <point x="565" y="480" type="line"/>
-      <point x="565" y="700" type="line"/>
-      <point x="335" y="700" type="line"/>
-      <point x="335" y="480" type="line"/>
-      <point x="305" y="480" type="line"/>
-      <point x="305" y="700" type="line"/>
-    </contour>
-  </outline>
+	<unicode hex="0057"/>
+	<advance width="900"/>
+	<outline>
+		<contour>
+			<point x="10" y="700" type="line"/>
+			<point x="300" y="-20" type="line"/>
+			<point x="450" y="220" type="line"/>
+			<point x="600" y="-20" type="line"/>
+			<point x="890" y="700" type="line"/>
+			<point x="595" y="700" type="line"/>
+			<point x="595" y="480" type="line"/>
+			<point x="565" y="480" type="line"/>
+			<point x="565" y="700" type="line"/>
+			<point x="335" y="700" type="line"/>
+			<point x="335" y="480" type="line"/>
+			<point x="305" y="480" type="line"/>
+			<point x="305" y="700" type="line"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/X_.glif
+++ b/sources/baby-shark.ufo/glyphs/X_.glif
@@ -1,22 +1,23 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="X" format="2">
-  <advance width="600"/>
-  <outline>
-    <contour>
-      <point x="10" y="701" type="line"/>
-      <point x="285" y="700" type="line"/>
-      <point x="285" y="480" type="line"/>
-      <point x="315" y="480" type="line"/>
-      <point x="315" y="699" type="line"/>
-      <point x="590" y="700" type="line"/>
-      <point x="470" y="350" type="line"/>
-      <point x="589" y="-2" type="line"/>
-      <point x="315" y="0" type="line"/>
-      <point x="315" y="248" type="line"/>
-      <point x="285" y="248" type="line"/>
-      <point x="285" y="0" type="line"/>
-      <point x="10" y="0" type="line"/>
-      <point x="130" y="350" type="line"/>
-    </contour>
-  </outline>
+	<unicode hex="0058"/>
+	<advance width="600"/>
+	<outline>
+		<contour>
+			<point x="10" y="701" type="line"/>
+			<point x="285" y="700" type="line"/>
+			<point x="285" y="480" type="line"/>
+			<point x="315" y="480" type="line"/>
+			<point x="315" y="699" type="line"/>
+			<point x="590" y="700" type="line"/>
+			<point x="470" y="350" type="line"/>
+			<point x="589" y="-2" type="line"/>
+			<point x="315" y="0" type="line"/>
+			<point x="315" y="248" type="line"/>
+			<point x="285" y="248" type="line"/>
+			<point x="285" y="0" type="line"/>
+			<point x="10" y="0" type="line"/>
+			<point x="130" y="350" type="line"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/Y_.glif
+++ b/sources/baby-shark.ufo/glyphs/Y_.glif
@@ -1,18 +1,19 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="Y" format="2">
-  <advance width="600"/>
-  <outline>
-    <contour>
-      <point x="10" y="700" type="line"/>
-      <point x="285" y="700" type="line"/>
-      <point x="285" y="480" type="line"/>
-      <point x="315" y="480" type="line"/>
-      <point x="315" y="700" type="line"/>
-      <point x="590" y="700" type="line"/>
-      <point x="420" y="340" type="line"/>
-      <point x="420" y="0" type="line"/>
-      <point x="180" y="0" type="line"/>
-      <point x="180" y="340" type="line"/>
-    </contour>
-  </outline>
+	<unicode hex="0059"/>
+	<advance width="600"/>
+	<outline>
+		<contour>
+			<point x="10" y="700" type="line"/>
+			<point x="285" y="700" type="line"/>
+			<point x="285" y="480" type="line"/>
+			<point x="315" y="480" type="line"/>
+			<point x="315" y="700" type="line"/>
+			<point x="590" y="700" type="line"/>
+			<point x="420" y="340" type="line"/>
+			<point x="420" y="0" type="line"/>
+			<point x="180" y="0" type="line"/>
+			<point x="180" y="340" type="line"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/Z_.glif
+++ b/sources/baby-shark.ufo/glyphs/Z_.glif
@@ -1,16 +1,17 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="Z" format="2">
-  <advance width="500"/>
-  <outline>
-    <contour>
-      <point x="10" y="700" type="line"/>
-      <point x="500" y="700" type="line"/>
-      <point x="312" y="262" type="line"/>
-      <point x="490" y="262" type="line"/>
-      <point x="490" y="0" type="line"/>
-      <point x="0" y="0" type="line"/>
-      <point x="223" y="495" type="line"/>
-      <point x="10" y="494" type="line"/>
-    </contour>
-  </outline>
+	<unicode hex="005A"/>
+	<advance width="500"/>
+	<outline>
+		<contour>
+			<point x="10" y="700" type="line"/>
+			<point x="500" y="700" type="line"/>
+			<point x="312" y="262" type="line"/>
+			<point x="490" y="262" type="line"/>
+			<point x="490" y="0" type="line"/>
+			<point x="0" y="0" type="line"/>
+			<point x="223" y="495" type="line"/>
+			<point x="10" y="494" type="line"/>
+		</contour>
+	</outline>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/a.glif
+++ b/sources/baby-shark.ufo/glyphs/a.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="a" format="2">
-  <unicode hex="0061"/>
+	<unicode hex="0061"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/b.glif
+++ b/sources/baby-shark.ufo/glyphs/b.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="b" format="2">
-  <unicode hex="0062"/>
+	<unicode hex="0062"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/c.glif
+++ b/sources/baby-shark.ufo/glyphs/c.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="c" format="2">
-  <unicode hex="0063"/>
+	<unicode hex="0063"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/d.glif
+++ b/sources/baby-shark.ufo/glyphs/d.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="d" format="2">
-  <unicode hex="0064"/>
+	<unicode hex="0064"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/e.glif
+++ b/sources/baby-shark.ufo/glyphs/e.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="e" format="2">
-  <unicode hex="0065"/>
+	<unicode hex="0065"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/f.glif
+++ b/sources/baby-shark.ufo/glyphs/f.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="f" format="2">
-  <unicode hex="0066"/>
+	<unicode hex="0066"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/g.glif
+++ b/sources/baby-shark.ufo/glyphs/g.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="g" format="2">
-  <unicode hex="0067"/>
+	<unicode hex="0067"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/h.glif
+++ b/sources/baby-shark.ufo/glyphs/h.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="h" format="2">
-  <unicode hex="0068"/>
+	<unicode hex="0068"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/i.glif
+++ b/sources/baby-shark.ufo/glyphs/i.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="i" format="2">
-  <unicode hex="0069"/>
+	<unicode hex="0069"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/j.glif
+++ b/sources/baby-shark.ufo/glyphs/j.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="j" format="2">
-  <unicode hex="006A"/>
+	<unicode hex="006A"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/k.glif
+++ b/sources/baby-shark.ufo/glyphs/k.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="k" format="2">
-  <unicode hex="006B"/>
+	<unicode hex="006B"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/l.glif
+++ b/sources/baby-shark.ufo/glyphs/l.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="l" format="2">
-  <unicode hex="006C"/>
+	<unicode hex="006C"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/m.glif
+++ b/sources/baby-shark.ufo/glyphs/m.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="m" format="2">
-  <unicode hex="006D"/>
+	<unicode hex="006D"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/n.glif
+++ b/sources/baby-shark.ufo/glyphs/n.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="n" format="2">
-  <unicode hex="006E"/>
+	<unicode hex="006E"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/o.glif
+++ b/sources/baby-shark.ufo/glyphs/o.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="o" format="2">
-  <unicode hex="006F"/>
+	<unicode hex="006F"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/p.glif
+++ b/sources/baby-shark.ufo/glyphs/p.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="p" format="2">
-  <unicode hex="0070"/>
+	<unicode hex="0070"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/q.glif
+++ b/sources/baby-shark.ufo/glyphs/q.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="q" format="2">
-  <unicode hex="0071"/>
+	<unicode hex="0071"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/r.glif
+++ b/sources/baby-shark.ufo/glyphs/r.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="r" format="2">
-  <unicode hex="0072"/>
+	<unicode hex="0072"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/s.glif
+++ b/sources/baby-shark.ufo/glyphs/s.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="s" format="2">
-  <unicode hex="0073"/>
+	<unicode hex="0073"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/t.glif
+++ b/sources/baby-shark.ufo/glyphs/t.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="t" format="2">
-  <unicode hex="0074"/>
+	<unicode hex="0074"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/u.glif
+++ b/sources/baby-shark.ufo/glyphs/u.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="u" format="2">
-  <unicode hex="0075"/>
+	<unicode hex="0075"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/v.glif
+++ b/sources/baby-shark.ufo/glyphs/v.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="v" format="2">
-  <unicode hex="0076"/>
+	<unicode hex="0076"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/w.glif
+++ b/sources/baby-shark.ufo/glyphs/w.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="w" format="2">
-  <unicode hex="0077"/>
+	<unicode hex="0077"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/x.glif
+++ b/sources/baby-shark.ufo/glyphs/x.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="x" format="2">
-  <unicode hex="0078"/>
+	<unicode hex="0078"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/y.glif
+++ b/sources/baby-shark.ufo/glyphs/y.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="y" format="2">
-  <unicode hex="0079"/>
+	<unicode hex="0079"/>
 </glyph>

--- a/sources/baby-shark.ufo/glyphs/z.glif
+++ b/sources/baby-shark.ufo/glyphs/z.glif
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="z" format="2">
-  <unicode hex="007A"/>
+	<unicode hex="007A"/>
 </glyph>


### PR DESCRIPTION
I notice you ran this through some other normalization tool or something? The diff is larger than it should be. In any case this is motivated by https://github.com/linebender/runebender/issues/233; preview doesn't work without unicode values set.

Feel free to ignore this PR and do it some other way if you like, I personally wouldn't like merging this if I were you 😛 